### PR TITLE
Get dagless building with recent GHC

### DIFF
--- a/dagless.cabal
+++ b/dagless.cabal
@@ -12,7 +12,7 @@ library
   build-depends:    base
                   , indexed
                   , indexed-extras
-                  , template-haskell
+                  , template-haskell >= 2.16
   default-language: Haskell2010
   exposed-modules:  Dagless
                   , Dagless.Types

--- a/src/Data/Tuple/Morph/TH.hs
+++ b/src/Data/Tuple/Morph/TH.hs
@@ -37,7 +37,7 @@ mkHListP []       = ConP (mkName "HNil") []
 
 -- | The tuple expression.
 mkTupleE :: [Name] -> Exp
-mkTupleE = TupE . fmap VarE
+mkTupleE = TupE . fmap (Just . VarE)
 
 -- | The HList expression.
 mkHListE :: [Name] -> Exp


### PR DESCRIPTION
I was trying to get dagless building with GHC-8.10.  I needed to fix a small `template-haskell` problem.

In `template-haskell-2.16.0.0` (which is bundled with GHC-8.10.1), the type of the `TupE` constructor has changed:

https://hackage.haskell.org/package/template-haskell-2.16.0.0/changelog

Note that this PR means that GHC < 8.10 will no longer be supported.  Alternatively, CPP could be used to support both old and new versions of `template-haskell`.